### PR TITLE
Add train times feature for Deutsche Bahn

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -52,7 +52,9 @@ export const REDIRECT_URI = process.env.REDIRECT_URI ?? `${FRONTEND_URL}/`;
 export const REGISTER_REDIRECT_URI = process.env.REGISTER_REDIRECT_URI ?? `${FRONTEND_URL}/registration`;
 export const FAILURE_REDIRECT_URI = process.env.FAILURE_REDIRECT_URI ?? `${FRONTEND_URL}/error`;
 
-export const ALLOWED_URLS = [WEATHER_API_URL, OPENWEATHER_URL, GEOCODE_URL];
+export const DB_API_BASE_URL = 'https://v6.db.transport.rest';
+
+export const ALLOWED_URLS = [WEATHER_API_URL, OPENWEATHER_URL, GEOCODE_URL, DB_API_BASE_URL];
 
 export const RATE_LIMIT = {
   windowMs: 1 * 60 * 1000, // 1 minute

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import { default as CalendarsRoute } from 'routes/calendars';
 import { default as BirthdaysRoute } from 'routes/birthdays';
 import { default as UsersRoute } from 'routes/users';
 import { default as LocationRoute } from 'routes/location';
+import { default as TrainsRoute } from 'routes/trains';
 import { NextFunction, Request, Response } from 'express';
 import { ApiError } from 'models/api/api_error';
 import { EXPRESS_ERROR_LOGGER, LOGGER } from 'services/loggers';
@@ -22,6 +23,7 @@ server.app.use('/api/birthdays', BirthdaysRoute);
 
 server.app.use('/api/users', UsersRoute);
 server.app.use('/api/location', LocationRoute);
+server.app.use('/api/trains', TrainsRoute);
 
 // ERROR HANDLING MIDDLEWARE
 server.app.use(EXPRESS_ERROR_LOGGER);

--- a/backend/src/models/api/trains.ts
+++ b/backend/src/models/api/trains.ts
@@ -1,0 +1,83 @@
+/**
+ * Types for Deutsche Bahn train data from v6.db.transport.rest API
+ */
+
+export interface TrainLocation {
+  type: 'location' | 'stop' | 'station';
+  id: string;
+  name: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface TrainLine {
+  type: string;
+  id?: string;
+  name: string;
+  mode: string;
+  product: string;
+}
+
+export interface TrainStop {
+  stop: TrainLocation;
+  departure?: string;
+  departureDelay?: number;
+  departurePlatform?: string;
+  arrival?: string;
+  arrivalDelay?: number;
+  arrivalPlatform?: string;
+}
+
+export interface TrainDeparture {
+  tripId: string;
+  stop: TrainLocation;
+  when: string;
+  plannedWhen: string;
+  delay?: number;
+  platform?: string;
+  plannedPlatform?: string;
+  direction: string;
+  line: TrainLine;
+  remarks?: Array<{
+    type: string;
+    code?: string;
+    text: string;
+  }>;
+}
+
+export interface TrainJourney {
+  type: 'journey';
+  legs: Array<{
+    origin: TrainStop;
+    destination: TrainStop;
+    departure: string;
+    arrival: string;
+    line?: TrainLine;
+    direction?: string;
+  }>;
+  price?: {
+    amount: number;
+    currency: string;
+  };
+}
+
+// Simplified response types for frontend
+export interface ApiTrainStation {
+  id: string;
+  name: string;
+  latitude?: number;
+  longitude?: number;
+}
+
+export interface ApiTrainConnection {
+  departure: string;
+  arrival: string;
+  departureStation: string;
+  arrivalStation: string;
+  departurePlatform?: string;
+  arrivalPlatform?: string;
+  line: string;
+  direction: string;
+  delay?: number;
+  duration: number;
+}

--- a/backend/src/models/api/trains.ts
+++ b/backend/src/models/api/trains.ts
@@ -2,12 +2,20 @@
  * Types for Deutsche Bahn train data from v6.db.transport.rest API
  */
 
+export interface TrainLocationCoordinates {
+  type: string;
+  id: string;
+  latitude: number;
+  longitude: number;
+}
+
 export interface TrainLocation {
   type: 'location' | 'stop' | 'station';
   id: string;
   name: string;
-  latitude?: number;
-  longitude?: number;
+  location?: TrainLocationCoordinates;
+  // Some stops have a nested station object
+  station?: TrainLocation;
 }
 
 export interface TrainLine {
@@ -45,15 +53,40 @@ export interface TrainDeparture {
   }>;
 }
 
+export interface TrainLeg {
+  origin: TrainLocation;
+  destination: TrainLocation;
+  departure: string;
+  plannedDeparture: string;
+  departureDelay?: number | null;
+  arrival: string;
+  plannedArrival: string;
+  arrivalDelay?: number | null;
+  tripId?: string;
+  line?: TrainLine;
+  direction?: string;
+  departurePlatform?: string;
+  plannedDeparturePlatform?: string;
+  arrivalPlatform?: string;
+  plannedArrivalPlatform?: string;
+  remarks?: Array<{
+    type: string;
+    code?: string;
+    text: string;
+    summary?: string;
+    priority?: number;
+  }>;
+  loadFactor?: string;
+}
+
 export interface TrainJourney {
   type: 'journey';
-  legs: Array<{
-    origin: TrainStop;
-    destination: TrainStop;
-    departure: string;
-    arrival: string;
-    line?: TrainLine;
-    direction?: string;
+  legs: TrainLeg[];
+  refreshToken?: string;
+  remarks?: Array<{
+    type: string;
+    code?: string;
+    text: string;
   }>;
   price?: {
     amount: number;

--- a/backend/src/models/api/user_settings.ts
+++ b/backend/src/models/api/user_settings.ts
@@ -4,4 +4,8 @@ export type ApiDtoUserSettings = {
   zip_code: string;
   events_cal_id: string;
   birthday_cal_id: string;
+  train_departure_station_id?: string;
+  train_departure_station_name?: string;
+  train_arrival_station_id?: string;
+  train_arrival_station_name?: string;
 };

--- a/backend/src/models/mongo/user_settings.ts
+++ b/backend/src/models/mongo/user_settings.ts
@@ -7,6 +7,10 @@ export interface IDtoUserSettings extends Document {
   events_cal_id: string;
   birthday_cal_id: string;
   sub: string;
+  train_departure_station_id?: string;
+  train_departure_station_name?: string;
+  train_arrival_station_id?: string;
+  train_arrival_station_name?: string;
 }
 
 const UserSettingsSchema = new Schema(
@@ -34,6 +38,22 @@ const UserSettingsSchema = new Schema(
       required: false,
     },
     events_cal_id: {
+      type: String,
+      required: false,
+    },
+    train_departure_station_id: {
+      type: String,
+      required: false,
+    },
+    train_departure_station_name: {
+      type: String,
+      required: false,
+    },
+    train_arrival_station_id: {
+      type: String,
+      required: false,
+    },
+    train_arrival_station_name: {
       type: String,
       required: false,
     },

--- a/backend/src/routes/trains/index.ts
+++ b/backend/src/routes/trains/index.ts
@@ -1,0 +1,134 @@
+import { getRouter } from 'services/router_factory';
+import { RegexParameterValidator } from 'services/validators/regex_parameter_validator';
+import { RangeParameterValidator } from 'services/validators/range_parameter_validator';
+import { EParamType } from 'services/validators/parameter_validator';
+import { NextFunction, Request, Response } from 'express';
+import { ApiError } from 'models/api/api_error';
+import { DeutscheBahnService } from 'services/deutsche_bahn';
+
+// Validators
+const queryValidator = new RegexParameterValidator('query', /^.{2,}$/, EParamType.query, true);
+
+const stationIdValidator = new RegexParameterValidator(
+  'stationId',
+  /^[\w-]+$/,
+  EParamType.query,
+  true,
+);
+
+const fromStationIdValidator = new RegexParameterValidator(
+  'from',
+  /^[\w-]+$/,
+  EParamType.query,
+  true,
+);
+
+const toStationIdValidator = new RegexParameterValidator('to', /^[\w-]+$/, EParamType.query, true);
+
+const resultsValidator = new RangeParameterValidator(
+  'results',
+  { min: 1, max: 50 },
+  EParamType.query,
+  false,
+);
+
+const durationValidator = new RangeParameterValidator(
+  'duration',
+  { min: 10, max: 720 },
+  EParamType.query,
+  false,
+);
+
+/**
+ * GET /api/trains/stations
+ * Search for train stations by name
+ * Query params:
+ *   - query: string (required, min 2 chars)
+ *   - results: number (optional, 1-50, default 10)
+ */
+async function searchStations(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const query = req.query.query as string;
+    const results = req.query.results ? parseInt(req.query.results as string, 10) : 10;
+
+    const stations = await DeutscheBahnService.searchStations(query, results);
+
+    res.status(200).json(stations);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      next(err);
+    } else {
+      next(new ApiError('Error searching train stations', err as Error, 500));
+    }
+  }
+}
+
+/**
+ * GET /api/trains/departures
+ * Get upcoming departures from a station
+ * Query params:
+ *   - stationId: string (required)
+ *   - duration: number (optional, 10-720 minutes, default 120)
+ *   - results: number (optional, 1-50, default 20)
+ */
+async function getDepartures(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const stationId = req.query.stationId as string;
+    const duration = req.query.duration ? parseInt(req.query.duration as string, 10) : 120;
+    const results = req.query.results ? parseInt(req.query.results as string, 10) : 20;
+
+    const departures = await DeutscheBahnService.getDepartures(stationId, duration, results);
+
+    res.status(200).json(departures);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      next(err);
+    } else {
+      next(new ApiError('Error getting train departures', err as Error, 500));
+    }
+  }
+}
+
+/**
+ * GET /api/trains/connections
+ * Get train connections between two stations
+ * Query params:
+ *   - from: string (required, departure station ID)
+ *   - to: string (required, arrival station ID)
+ *   - results: number (optional, 1-50, default 5)
+ */
+async function getConnections(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const from = req.query.from as string;
+    const to = req.query.to as string;
+    const results = req.query.results ? parseInt(req.query.results as string, 10) : 5;
+
+    const connections = await DeutscheBahnService.getConnections(from, to, results);
+
+    res.status(200).json(connections);
+  } catch (err) {
+    if (err instanceof ApiError) {
+      next(err);
+    } else {
+      next(new ApiError('Error getting train connections', err as Error, 500));
+    }
+  }
+}
+
+const router = getRouter();
+
+router.get('/stations', [queryValidator.validate, resultsValidator.validate], searchStations);
+
+router.get(
+  '/departures',
+  [stationIdValidator.validate, durationValidator.validate, resultsValidator.validate],
+  getDepartures,
+);
+
+router.get(
+  '/connections',
+  [fromStationIdValidator.validate, toStationIdValidator.validate, resultsValidator.validate],
+  getConnections,
+);
+
+export default router;

--- a/backend/src/routes/trains/index.ts
+++ b/backend/src/routes/trains/index.ts
@@ -9,35 +9,15 @@ import { DeutscheBahnService } from 'services/deutsche_bahn';
 // Validators
 const queryValidator = new RegexParameterValidator('query', /^.{2,}$/, EParamType.query, true);
 
-const stationIdValidator = new RegexParameterValidator(
-  'stationId',
-  /^[\w-]+$/,
-  EParamType.query,
-  true,
-);
+const stationIdValidator = new RegexParameterValidator('stationId', /^[\w-]+$/, EParamType.query, true);
 
-const fromStationIdValidator = new RegexParameterValidator(
-  'from',
-  /^[\w-]+$/,
-  EParamType.query,
-  true,
-);
+const fromStationIdValidator = new RegexParameterValidator('from', /^[\w-]+$/, EParamType.query, true);
 
 const toStationIdValidator = new RegexParameterValidator('to', /^[\w-]+$/, EParamType.query, true);
 
-const resultsValidator = new RangeParameterValidator(
-  'results',
-  { min: 1, max: 50 },
-  EParamType.query,
-  false,
-);
+const resultsValidator = new RangeParameterValidator('results', { min: 1, max: 50 }, EParamType.query, false);
 
-const durationValidator = new RangeParameterValidator(
-  'duration',
-  { min: 10, max: 720 },
-  EParamType.query,
-  false,
-);
+const durationValidator = new RangeParameterValidator('duration', { min: 10, max: 720 }, EParamType.query, false);
 
 /**
  * GET /api/trains/stations

--- a/backend/src/routes/users/services.ts
+++ b/backend/src/routes/users/services.ts
@@ -44,6 +44,10 @@ export class UserSettingsRepository {
           city: settings.city,
           events_cal_id: settings.events_cal_id,
           birthday_cal_id: settings.birthday_cal_id,
+          train_departure_station_id: settings?.train_departure_station_id,
+          train_departure_station_name: settings?.train_departure_station_name,
+          train_arrival_station_id: settings?.train_arrival_station_id,
+          train_arrival_station_name: settings?.train_arrival_station_name,
         },
       },
       {

--- a/backend/src/routes/users/settings.ts
+++ b/backend/src/routes/users/settings.ts
@@ -34,6 +34,10 @@ class UserSettingsService {
       city: userSettings.city,
       events_cal_id: userSettings.events_cal_id,
       birthday_cal_id: userSettings.birthday_cal_id,
+      train_departure_station_id: userSettings?.train_departure_station_id,
+      train_departure_station_name: userSettings?.train_departure_station_name,
+      train_arrival_station_id: userSettings?.train_arrival_station_id,
+      train_arrival_station_name: userSettings?.train_arrival_station_name,
     };
   }
 }

--- a/backend/src/services/deutsche_bahn.ts
+++ b/backend/src/services/deutsche_bahn.ts
@@ -1,0 +1,151 @@
+import { fetchJson } from './fetch';
+import { ApiError } from 'models/api/api_error';
+import {
+  TrainLocation,
+  TrainDeparture,
+  ApiTrainStation,
+  ApiTrainConnection,
+  TrainJourney,
+} from 'models/api/trains';
+import { LOGGER } from './loggers';
+
+const DB_API_BASE_URL = 'https://v6.db.transport.rest';
+
+export class DeutscheBahnService {
+  /**
+   * Search for train stations by name
+   * @param query - Search query (station name)
+   * @param results - Maximum number of results (default: 10)
+   * @returns Array of matching stations
+   */
+  static async searchStations(query: string, results: number = 10): Promise<ApiTrainStation[]> {
+    try {
+      const url = `${DB_API_BASE_URL}/locations?query=${encodeURIComponent(query)}&results=${results}&poi=false&addresses=false`;
+
+      LOGGER.info('Searching for train stations', { query, results, url });
+
+      const response = await fetchJson(url);
+
+      if (!Array.isArray(response.body)) {
+        throw new ApiError('Invalid response from Deutsche Bahn API', undefined, 500);
+      }
+
+      const locations = response.body as TrainLocation[];
+
+      // Filter to only include stations and stops
+      const stations: ApiTrainStation[] = locations
+        .filter((loc) => loc.type === 'station' || loc.type === 'stop')
+        .map((loc) => ({
+          id: loc.id,
+          name: loc.name,
+          latitude: loc.latitude,
+          longitude: loc.longitude,
+        }));
+
+      return stations;
+    } catch (error) {
+      LOGGER.error('Error searching train stations', { error, query });
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw new ApiError('Failed to search train stations', error as Error, 500);
+    }
+  }
+
+  /**
+   * Get upcoming departures from a station
+   * @param stationId - Station ID
+   * @param duration - Duration in minutes to look ahead (default: 120)
+   * @param results - Maximum number of results (default: 20)
+   * @returns Array of departures
+   */
+  static async getDepartures(
+    stationId: string,
+    duration: number = 120,
+    results: number = 20,
+  ): Promise<TrainDeparture[]> {
+    try {
+      const url = `${DB_API_BASE_URL}/stops/${encodeURIComponent(stationId)}/departures?duration=${duration}&results=${results}`;
+
+      LOGGER.info('Getting train departures', { stationId, duration, results, url });
+
+      const response = await fetchJson(url);
+
+      if (!response.body || !Array.isArray(response.body.departures)) {
+        throw new ApiError('Invalid response from Deutsche Bahn API', undefined, 500);
+      }
+
+      return response.body.departures as TrainDeparture[];
+    } catch (error) {
+      LOGGER.error('Error getting train departures', { error, stationId });
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw new ApiError('Failed to get train departures', error as Error, 500);
+    }
+  }
+
+  /**
+   * Get train connections between two stations
+   * @param fromStationId - Departure station ID
+   * @param toStationId - Arrival station ID
+   * @param results - Maximum number of results (default: 5)
+   * @returns Array of train connections
+   */
+  static async getConnections(
+    fromStationId: string,
+    toStationId: string,
+    results: number = 5,
+  ): Promise<ApiTrainConnection[]> {
+    try {
+      const url = `${DB_API_BASE_URL}/journeys?from=${encodeURIComponent(fromStationId)}&to=${encodeURIComponent(toStationId)}&results=${results}`;
+
+      LOGGER.info('Getting train connections', { fromStationId, toStationId, results, url });
+
+      const response = await fetchJson(url);
+
+      if (!response.body || !Array.isArray(response.body.journeys)) {
+        throw new ApiError('Invalid response from Deutsche Bahn API', undefined, 500);
+      }
+
+      const journeys = response.body.journeys as TrainJourney[];
+
+      // Transform journeys into simplified connection objects
+      const connections: ApiTrainConnection[] = [];
+
+      for (const journey of journeys) {
+        if (!journey.legs || journey.legs.length === 0) {
+          continue;
+        }
+
+        const firstLeg = journey.legs[0];
+        const lastLeg = journey.legs[journey.legs.length - 1];
+
+        const departure = new Date(firstLeg.departure);
+        const arrival = new Date(lastLeg.arrival);
+        const duration = Math.floor((arrival.getTime() - departure.getTime()) / 1000 / 60); // minutes
+
+        connections.push({
+          departure: firstLeg.departure,
+          arrival: lastLeg.arrival,
+          departureStation: firstLeg.origin.stop.name,
+          arrivalStation: lastLeg.destination.stop.name,
+          departurePlatform: firstLeg.origin.departurePlatform,
+          arrivalPlatform: lastLeg.destination.arrivalPlatform,
+          line: firstLeg.line?.name || 'Unknown',
+          direction: firstLeg.direction || lastLeg.destination.stop.name,
+          delay: firstLeg.origin.departureDelay,
+          duration,
+        });
+      }
+
+      return connections;
+    } catch (error) {
+      LOGGER.error('Error getting train connections', { error, fromStationId, toStationId });
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw new ApiError('Failed to get train connections', error as Error, 500);
+    }
+  }
+}

--- a/backend/src/tests/setup.ts
+++ b/backend/src/tests/setup.ts
@@ -302,6 +302,275 @@ beforeEach(() => {
       // If URL parsing fails, fall through to the default mock response below.
     }
 
+    // Mock Deutsche Bahn API (v6.db.transport.rest)
+    if (urlString.includes('db.transport.rest')) {
+      // Mock /locations endpoint - returns array of stations
+      if (urlString.includes('/locations')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers(),
+          json: async () => [
+            {
+              type: 'station',
+              id: '8011160',
+              name: 'Berlin Hbf',
+              location: {
+                type: 'location',
+                id: '8011160',
+                latitude: 52.525589,
+                longitude: 13.369438,
+              },
+            },
+            {
+              type: 'station',
+              id: '8011162',
+              name: 'Berlin Ostbahnhof',
+              location: {
+                type: 'location',
+                id: '8011162',
+                latitude: 52.510972,
+                longitude: 13.434567,
+              },
+            },
+            {
+              type: 'station',
+              id: '8089021',
+              name: 'Berlin Friedrichstraße',
+              location: {
+                type: 'location',
+                id: '8089021',
+                latitude: 52.520277,
+                longitude: 13.386944,
+              },
+            },
+          ],
+          arrayBuffer: async () => new ArrayBuffer(8),
+          text: async () => '',
+          blob: async () => new Blob(),
+          formData: async () => new FormData(),
+          clone: () => ({ ok: true }) as Response,
+        } as Response);
+      }
+
+      // Mock /stops/{stationId}/departures endpoint - returns journeys array
+      if (urlString.includes('/stops/') && urlString.includes('/departures')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers(),
+          json: async () => ({
+            journeys: [
+              {
+                type: 'journey',
+                legs: [
+                  {
+                    origin: {
+                      type: 'station',
+                      id: '8011160',
+                      name: 'Berlin Hbf',
+                      location: { latitude: 52.525589, longitude: 13.369438 },
+                    },
+                    destination: {
+                      type: 'station',
+                      id: '8000261',
+                      name: 'München Hbf',
+                      location: { latitude: 48.140232, longitude: 11.558335 },
+                    },
+                    departure: '2024-01-15T10:00:00+01:00',
+                    plannedDeparture: '2024-01-15T10:00:00+01:00',
+                    departureDelay: 0,
+                    arrival: '2024-01-15T14:30:00+01:00',
+                    departurePlatform: '5',
+                    plannedDeparturePlatform: '5',
+                    direction: 'München Hbf',
+                    line: {
+                      type: 'line',
+                      id: 'ice-1234',
+                      name: 'ICE 1234',
+                      mode: 'train',
+                      product: 'nationalExpress',
+                    },
+                    remarks: [],
+                  },
+                ],
+                refreshToken: 'mock-token-1',
+              },
+              {
+                type: 'journey',
+                legs: [
+                  {
+                    origin: {
+                      type: 'station',
+                      id: '8011160',
+                      name: 'Berlin Hbf',
+                      location: { latitude: 52.525589, longitude: 13.369438 },
+                    },
+                    destination: {
+                      type: 'station',
+                      id: '8000105',
+                      name: 'Frankfurt(Main)Hbf',
+                      location: { latitude: 50.107145, longitude: 8.663789 },
+                    },
+                    departure: '2024-01-15T10:30:00+01:00',
+                    plannedDeparture: '2024-01-15T10:30:00+01:00',
+                    departureDelay: 300,
+                    arrival: '2024-01-15T14:45:00+01:00',
+                    departurePlatform: '8',
+                    plannedDeparturePlatform: '8',
+                    direction: 'Frankfurt(Main)Hbf',
+                    line: {
+                      type: 'line',
+                      id: 'ice-5678',
+                      name: 'ICE 5678',
+                      mode: 'train',
+                      product: 'nationalExpress',
+                    },
+                    remarks: [],
+                  },
+                ],
+                refreshToken: 'mock-token-2',
+              },
+            ],
+          }),
+          arrayBuffer: async () => new ArrayBuffer(8),
+          text: async () => '',
+          blob: async () => new Blob(),
+          formData: async () => new FormData(),
+          clone: () => ({ ok: true }) as Response,
+        } as Response);
+      }
+
+      // Mock /journeys endpoint - returns journeys array for connections
+      if (urlString.includes('/journeys')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers(),
+          json: async () => ({
+            journeys: [
+              {
+                type: 'journey',
+                legs: [
+                  {
+                    origin: {
+                      type: 'station',
+                      id: '8011160',
+                      name: 'Berlin Hbf',
+                      location: { latitude: 52.525589, longitude: 13.369438 },
+                    },
+                    destination: {
+                      type: 'station',
+                      id: '8000261',
+                      name: 'München Hbf',
+                      location: { latitude: 48.140232, longitude: 11.558335 },
+                    },
+                    departure: '2024-01-15T10:00:00+01:00',
+                    plannedDeparture: '2024-01-15T10:00:00+01:00',
+                    departureDelay: 0,
+                    arrival: '2024-01-15T14:30:00+01:00',
+                    arrivalPlatform: '12',
+                    departurePlatform: '5',
+                    plannedDeparturePlatform: '5',
+                    direction: 'München Hbf',
+                    line: {
+                      type: 'line',
+                      id: 'ice-1234',
+                      name: 'ICE 1234',
+                      mode: 'train',
+                      product: 'nationalExpress',
+                    },
+                    remarks: [],
+                  },
+                ],
+                refreshToken: 'mock-token-1',
+              },
+              {
+                type: 'journey',
+                legs: [
+                  {
+                    origin: {
+                      type: 'station',
+                      id: '8011160',
+                      name: 'Berlin Hbf',
+                      location: { latitude: 52.525589, longitude: 13.369438 },
+                    },
+                    destination: {
+                      type: 'station',
+                      id: '8000261',
+                      name: 'München Hbf',
+                      location: { latitude: 48.140232, longitude: 11.558335 },
+                    },
+                    departure: '2024-01-15T11:00:00+01:00',
+                    plannedDeparture: '2024-01-15T11:00:00+01:00',
+                    departureDelay: 300,
+                    arrival: '2024-01-15T15:30:00+01:00',
+                    arrivalPlatform: '14',
+                    departurePlatform: '7',
+                    plannedDeparturePlatform: '7',
+                    direction: 'München Hbf',
+                    line: {
+                      type: 'line',
+                      id: 'ice-5678',
+                      name: 'ICE 5678',
+                      mode: 'train',
+                      product: 'nationalExpress',
+                    },
+                    remarks: [],
+                  },
+                ],
+                refreshToken: 'mock-token-2',
+              },
+              {
+                type: 'journey',
+                legs: [
+                  {
+                    origin: {
+                      type: 'station',
+                      id: '8011160',
+                      name: 'Berlin Hbf',
+                      location: { latitude: 52.525589, longitude: 13.369438 },
+                    },
+                    destination: {
+                      type: 'station',
+                      id: '8000261',
+                      name: 'München Hbf',
+                      location: { latitude: 48.140232, longitude: 11.558335 },
+                    },
+                    departure: '2024-01-15T12:00:00+01:00',
+                    plannedDeparture: '2024-01-15T12:00:00+01:00',
+                    departureDelay: 0,
+                    arrival: '2024-01-15T16:30:00+01:00',
+                    arrivalPlatform: '12',
+                    departurePlatform: '5',
+                    plannedDeparturePlatform: '5',
+                    direction: 'München Hbf',
+                    line: {
+                      type: 'line',
+                      id: 'ice-9012',
+                      name: 'ICE 9012',
+                      mode: 'train',
+                      product: 'nationalExpress',
+                    },
+                    remarks: [],
+                  },
+                ],
+                refreshToken: 'mock-token-3',
+              },
+            ],
+          }),
+          arrayBuffer: async () => new ArrayBuffer(8),
+          text: async () => '',
+          blob: async () => new Blob(),
+          formData: async () => new FormData(),
+          clone: () => ({ ok: true }) as Response,
+        } as Response);
+      }
+    }
+
     // Default mock response
     return Promise.resolve({
       ok: true,

--- a/backend/src/tests/trains.test.ts
+++ b/backend/src/tests/trains.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import request from 'supertest';
+import app from '../index';
+
+const ROUTE = '/api/trains';
+
+describe(`Unit test the ${ROUTE} route`, () => {
+  const test_params = {
+    valid_query: 'Berlin',
+    valid_query_hbf: 'Berlin Hbf',
+    short_query: 'B',
+    valid_station_id: '8011160', // Berlin Hbf
+    invalid_station_id: 'invalid123',
+    berlin_hbf_id: '8011160',
+    munich_hbf_id: '8000261',
+  };
+
+  describe(`Unit testing the ${ROUTE}/stations route`, () => {
+    it('should return 400 when query parameter is missing', async () => {
+      const response = await request(app).get(`${ROUTE}/stations`);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 for query less than 2 characters', async () => {
+      const response = await request(app).get(`${ROUTE}/stations?query=${test_params.short_query}`);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return OK with valid query parameter', async () => {
+      const response = await request(app).get(`${ROUTE}/stations?query=${test_params.valid_query}`);
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should return stations with correct structure', async () => {
+      const response = await request(app).get(`${ROUTE}/stations?query=${test_params.valid_query_hbf}`);
+      if (response.status === 200 && response.body.length > 0) {
+        const station = response.body[0];
+        expect(typeof station.id).toBe('string');
+        expect(typeof station.name).toBe('string');
+        expect(station.id.length).toBeGreaterThan(0);
+        expect(station.name.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should respect results limit parameter', async () => {
+      const results = 3;
+      const response = await request(app).get(`${ROUTE}/stations?query=${test_params.valid_query}&results=${results}`);
+      if (response.status === 200) {
+        expect(response.body.length).toBeLessThanOrEqual(results);
+      }
+    });
+
+    it('should return 400 for results parameter out of range (too high)', async () => {
+      const response = await request(app).get(`${ROUTE}/stations?query=${test_params.valid_query}&results=100`);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 for results parameter out of range (too low)', async () => {
+      const response = await request(app).get(`${ROUTE}/stations?query=${test_params.valid_query}&results=0`);
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe(`Unit testing the ${ROUTE}/departures route`, () => {
+    it('should return 400 when stationId parameter is missing', async () => {
+      const response = await request(app).get(`${ROUTE}/departures`);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return OK with valid stationId', async () => {
+      const response = await request(app).get(`${ROUTE}/departures?stationId=${test_params.valid_station_id}`);
+      // May return 200 (success) or 500 (API error) depending on external API
+      expect(response.status === 200 || response.status === 500).toBe(true);
+    });
+
+    it('should return departures with correct structure', async () => {
+      const response = await request(app).get(`${ROUTE}/departures?stationId=${test_params.valid_station_id}`);
+      if (response.status === 200) {
+        expect(Array.isArray(response.body)).toBe(true);
+        if (response.body.length > 0) {
+          const departure = response.body[0];
+          expect('when' in departure || 'plannedWhen' in departure).toBe(true);
+          expect('line' in departure).toBe(true);
+          expect('direction' in departure).toBe(true);
+        }
+      }
+    });
+
+    it('should respect duration parameter', async () => {
+      const duration = 60;
+      const response = await request(app).get(
+        `${ROUTE}/departures?stationId=${test_params.valid_station_id}&duration=${duration}`,
+      );
+      expect(response.status === 200 || response.status === 500).toBe(true);
+    });
+
+    it('should return 400 for duration parameter out of range (too low)', async () => {
+      const response = await request(app).get(
+        `${ROUTE}/departures?stationId=${test_params.valid_station_id}&duration=5`,
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 for duration parameter out of range (too high)', async () => {
+      const response = await request(app).get(
+        `${ROUTE}/departures?stationId=${test_params.valid_station_id}&duration=800`,
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('should respect results parameter', async () => {
+      const results = 5;
+      const response = await request(app).get(
+        `${ROUTE}/departures?stationId=${test_params.valid_station_id}&results=${results}`,
+      );
+      if (response.status === 200) {
+        expect(response.body.length).toBeLessThanOrEqual(results);
+      }
+    });
+  });
+
+  describe(`Unit testing the ${ROUTE}/connections route`, () => {
+    it('should return 400 when from parameter is missing', async () => {
+      const response = await request(app).get(`${ROUTE}/connections?to=${test_params.munich_hbf_id}`);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 when to parameter is missing', async () => {
+      const response = await request(app).get(`${ROUTE}/connections?from=${test_params.berlin_hbf_id}`);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return OK with valid from and to parameters', async () => {
+      const response = await request(app).get(
+        `${ROUTE}/connections?from=${test_params.berlin_hbf_id}&to=${test_params.munich_hbf_id}`,
+      );
+      // May return 200 (success) or 500 (API error) depending on external API
+      expect(response.status === 200 || response.status === 500).toBe(true);
+    });
+
+    it('should return connections with correct structure', async () => {
+      const response = await request(app).get(
+        `${ROUTE}/connections?from=${test_params.berlin_hbf_id}&to=${test_params.munich_hbf_id}`,
+      );
+      if (response.status === 200) {
+        expect(Array.isArray(response.body)).toBe(true);
+        if (response.body.length > 0) {
+          const connection = response.body[0];
+          expect(typeof connection.departure).toBe('string');
+          expect(typeof connection.arrival).toBe('string');
+          expect(typeof connection.departureStation).toBe('string');
+          expect(typeof connection.arrivalStation).toBe('string');
+          expect(typeof connection.line).toBe('string');
+          expect(typeof connection.direction).toBe('string');
+          expect(typeof connection.duration).toBe('number');
+          expect(connection.duration).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('should respect results parameter', async () => {
+      const results = 3;
+      const response = await request(app).get(
+        `${ROUTE}/connections?from=${test_params.berlin_hbf_id}&to=${test_params.munich_hbf_id}&results=${results}`,
+      );
+      if (response.status === 200) {
+        expect(response.body.length).toBeLessThanOrEqual(results);
+      }
+    });
+
+    it('should return 400 for results parameter out of range', async () => {
+      const response = await request(app).get(
+        `${ROUTE}/connections?from=${test_params.berlin_hbf_id}&to=${test_params.munich_hbf_id}&results=100`,
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('should validate departure is before arrival', async () => {
+      const response = await request(app).get(
+        `${ROUTE}/connections?from=${test_params.berlin_hbf_id}&to=${test_params.munich_hbf_id}`,
+      );
+      if (response.status === 200 && response.body.length > 0) {
+        const connection = response.body[0];
+        const departureTime = new Date(connection.departure).getTime();
+        const arrivalTime = new Date(connection.arrival).getTime();
+        expect(departureTime).toBeLessThan(arrivalTime);
+      }
+    });
+  });
+});

--- a/frontend/src/apis/trains.ts
+++ b/frontend/src/apis/trains.ts
@@ -18,6 +18,42 @@ export const useSearchTrainStations = (
         staleTime: 300000, // 5 minutes
     })
 
+const DEFAULT_REFETCH_INTERVAL = 300000
+const DEPARTURE_BUFFER = 15000
+const MIN_REFETCH_INTERVAL = 10000
+
+/**
+ * Calculates the refetch interval based on the earliest train departure time.
+ * Returns the time until the earliest departure (plus buffer) or the default interval,
+ * whichever is smaller.
+ */
+const calculateRefetchInterval = (
+    data: TrainConnection[] | undefined
+): number => {
+    if (!data || data.length === 0) {
+        return DEFAULT_REFETCH_INTERVAL
+    }
+
+    const now = Date.now()
+
+    const earliestDeparture = data.reduce((earliest, connection) => {
+        const departureTime = new Date(connection.departure).getTime()
+        return departureTime < earliest ? departureTime : earliest
+    }, Infinity)
+
+    if (earliestDeparture === Infinity) {
+        return DEFAULT_REFETCH_INTERVAL
+    }
+
+    const timeUntilDeparture = earliestDeparture + DEPARTURE_BUFFER - now
+
+    if (timeUntilDeparture <= 0) {
+        return MIN_REFETCH_INTERVAL
+    }
+
+    return Math.min(timeUntilDeparture, DEFAULT_REFETCH_INTERVAL)
+}
+
 export const useGetTrainConnections = (
     fromStationId: string | undefined,
     toStationId: string | undefined,
@@ -34,6 +70,6 @@ export const useGetTrainConnections = (
                 `${TRAINS_API}/connections?from=${encodeURIComponent(fromStationId!)}&to=${encodeURIComponent(toStationId!)}&results=2`
             ),
         enabled: enabled && !!fromStationId && !!toStationId,
-        refetchInterval: 300000, // Refetch every 5 minutes
+        refetchInterval: (data) => calculateRefetchInterval(data),
         staleTime: 30000, // Consider data stale after 30 seconds
     })

--- a/frontend/src/apis/trains.ts
+++ b/frontend/src/apis/trains.ts
@@ -20,7 +20,7 @@ export const useSearchTrainStations = (
 
 const DEFAULT_REFETCH_INTERVAL = 300000
 const DEPARTURE_BUFFER = 15000
-const MIN_REFETCH_INTERVAL = 10000
+const MIN_REFETCH_INTERVAL = 15000
 
 /**
  * Calculates the refetch interval based on the earliest train departure time.

--- a/frontend/src/apis/trains.ts
+++ b/frontend/src/apis/trains.ts
@@ -24,7 +24,11 @@ export const useGetTrainConnections = (
     enabled: boolean = true
 ): UseQueryResult<TrainConnection[], Error> =>
     useQuery<TrainConnection[], Error>({
-        queryKey: [ServerStateKeysEnum.train_connections, fromStationId, toStationId],
+        queryKey: [
+            ServerStateKeysEnum.train_connections,
+            fromStationId,
+            toStationId,
+        ],
         queryFn: async (): Promise<TrainConnection[]> =>
             fetchJson<TrainConnection[]>(
                 `${TRAINS_API}/connections?from=${encodeURIComponent(fromStationId!)}&to=${encodeURIComponent(toStationId!)}&results=2`

--- a/frontend/src/apis/trains.ts
+++ b/frontend/src/apis/trains.ts
@@ -1,0 +1,35 @@
+import { useQuery, UseQueryResult } from 'react-query'
+import { fetchJson } from '../common/fetch'
+import { ServerStateKeysEnum } from '../common/statekeys'
+import { TRAINS_API } from '../constants/api'
+import { TrainStation, TrainConnection } from '../models/trains'
+
+export const useSearchTrainStations = (
+    query: string,
+    enabled: boolean = true
+): UseQueryResult<TrainStation[], Error> =>
+    useQuery<TrainStation[], Error>({
+        queryKey: [ServerStateKeysEnum.train_stations, query],
+        queryFn: async (): Promise<TrainStation[]> =>
+            fetchJson<TrainStation[]>(
+                `${TRAINS_API}/stations?query=${encodeURIComponent(query)}&results=10`
+            ),
+        enabled: enabled && query.length >= 2,
+        staleTime: 300000, // 5 minutes
+    })
+
+export const useGetTrainConnections = (
+    fromStationId: string | undefined,
+    toStationId: string | undefined,
+    enabled: boolean = true
+): UseQueryResult<TrainConnection[], Error> =>
+    useQuery<TrainConnection[], Error>({
+        queryKey: [ServerStateKeysEnum.train_connections, fromStationId, toStationId],
+        queryFn: async (): Promise<TrainConnection[]> =>
+            fetchJson<TrainConnection[]>(
+                `${TRAINS_API}/connections?from=${encodeURIComponent(fromStationId!)}&to=${encodeURIComponent(toStationId!)}&results=5`
+            ),
+        enabled: enabled && !!fromStationId && !!toStationId,
+        refetchInterval: 60000, // Refetch every minute
+        staleTime: 30000, // Consider data stale after 30 seconds
+    })

--- a/frontend/src/apis/trains.ts
+++ b/frontend/src/apis/trains.ts
@@ -27,9 +27,9 @@ export const useGetTrainConnections = (
         queryKey: [ServerStateKeysEnum.train_connections, fromStationId, toStationId],
         queryFn: async (): Promise<TrainConnection[]> =>
             fetchJson<TrainConnection[]>(
-                `${TRAINS_API}/connections?from=${encodeURIComponent(fromStationId!)}&to=${encodeURIComponent(toStationId!)}&results=5`
+                `${TRAINS_API}/connections?from=${encodeURIComponent(fromStationId!)}&to=${encodeURIComponent(toStationId!)}&results=2`
             ),
         enabled: enabled && !!fromStationId && !!toStationId,
-        refetchInterval: 60000, // Refetch every minute
+        refetchInterval: 300000, // Refetch every 5 minutes
         staleTime: 30000, // Consider data stale after 30 seconds
     })

--- a/frontend/src/apis/users.ts
+++ b/frontend/src/apis/users.ts
@@ -31,5 +31,9 @@ const getUserSettingsBody = async (
         city: data.city,
         events_cal_id: data.eventsCalId,
         birthday_cal_id: data.birthdayCalId,
+        train_departure_station_id: data.trainDepartureStationId,
+        train_departure_station_name: data.trainDepartureStationName,
+        train_arrival_station_id: data.trainArrivalStationId,
+        train_arrival_station_name: data.trainArrivalStationName,
     }
 }

--- a/frontend/src/common/statekeys.ts
+++ b/frontend/src/common/statekeys.ts
@@ -12,4 +12,6 @@ export enum ServerStateKeysEnum {
     geocode,
     calendar_list,
     min_time,
+    train_stations,
+    train_connections,
 }

--- a/frontend/src/components/train_times/TrainTimes.tsx
+++ b/frontend/src/components/train_times/TrainTimes.tsx
@@ -1,0 +1,174 @@
+import Typography from '@mui/material/Typography'
+import { Box, Skeleton, Stack } from '@mui/material'
+import { MediumCard } from '../CardFrame'
+import { memo } from 'react'
+import { useGetTrainConnections } from '../../apis/trains'
+import { useGetUserSettings } from '../../apis/user_settings'
+import { TrainConnection as TrainConnectionType } from '../../models/trains'
+import { xSmallFontSize } from '../../assets/styles/theme'
+
+const TrainTimesComponent = () => {
+    const { data: userSettings } = useGetUserSettings(false)
+
+    const departureStationId = userSettings?.train_departure_station_id
+    const arrivalStationId = userSettings?.train_arrival_station_id
+    const departureStationName = userSettings?.train_departure_station_name
+    const arrivalStationName = userSettings?.train_arrival_station_name
+
+    const enabled = !!departureStationId && !!arrivalStationId
+
+    const {
+        data: connections,
+        isLoading,
+        error,
+    } = useGetTrainConnections(departureStationId, arrivalStationId, enabled)
+
+    if (!enabled) {
+        return null // Don't render if no stations are configured
+    }
+
+    return (
+        <MediumCard>
+            <Box height="100%">
+                <Typography variant="body1" marginBottom={1}>
+                    TRAIN TIMES
+                </Typography>
+                <Typography
+                    variant="body2"
+                    fontSize={xSmallFontSize}
+                    color="text.secondary"
+                    marginBottom={2}
+                >
+                    {departureStationName} → {arrivalStationName}
+                </Typography>
+                <Stack spacing={1} direction="column">
+                    {isLoading && (
+                        <>
+                            {Array.from({ length: 3 }, (_, index) => (
+                                <Skeleton key={index} variant="rounded" height={60} />
+                            ))}
+                        </>
+                    )}
+
+                    {error && (
+                        <Typography color="error" fontSize={xSmallFontSize}>
+                            Error loading train connections
+                        </Typography>
+                    )}
+
+                    {!isLoading &&
+                        !error &&
+                        connections &&
+                        connections.length === 0 && (
+                            <Typography
+                                color="text.secondary"
+                                fontSize={xSmallFontSize}
+                            >
+                                No connections found
+                            </Typography>
+                        )}
+
+                    {!isLoading &&
+                        !error &&
+                        connections &&
+                        connections.map((connection, index) => (
+                            <TrainConnection
+                                key={`${connection.departure}-${index}`}
+                                connection={connection}
+                            />
+                        ))}
+                </Stack>
+            </Box>
+        </MediumCard>
+    )
+}
+
+interface TrainConnectionProps {
+    connection: TrainConnectionType
+}
+
+const TrainConnectionComponent = ({ connection }: TrainConnectionProps) => {
+    const departureTime = new Date(connection.departure)
+    const arrivalTime = new Date(connection.arrival)
+
+    const formatTime = (date: Date): string => {
+        return date.toLocaleTimeString('en-GB', {
+            hour: '2-digit',
+            minute: '2-digit',
+        })
+    }
+
+    const formatDuration = (minutes: number): string => {
+        const hours = Math.floor(minutes / 60)
+        const mins = minutes % 60
+        if (hours > 0) {
+            return `${hours}h ${mins}m`
+        }
+        return `${mins}m`
+    }
+
+    const getDelayColor = (delay?: number): string => {
+        if (!delay || delay === 0) return 'text.primary'
+        if (delay > 0 && delay <= 5) return 'warning.main'
+        return 'error.main'
+    }
+
+    return (
+        <Box
+            sx={{
+                padding: 1,
+                borderRadius: 1,
+                backgroundColor: 'background.paper',
+                border: 1,
+                borderColor: 'divider',
+            }}
+        >
+            <Box
+                display="flex"
+                justifyContent="space-between"
+                alignItems="center"
+            >
+                <Box>
+                    <Typography variant="body2" fontWeight="bold">
+                        {formatTime(departureTime)} → {formatTime(arrivalTime)}
+                    </Typography>
+                    <Typography
+                        variant="body2"
+                        fontSize={xSmallFontSize}
+                        color="text.secondary"
+                    >
+                        {connection.line} • {formatDuration(connection.duration)}
+                    </Typography>
+                </Box>
+                <Box textAlign="right">
+                    {connection.departurePlatform && (
+                        <Typography
+                            variant="body2"
+                            fontSize={xSmallFontSize}
+                            color="text.secondary"
+                        >
+                            Platform {connection.departurePlatform}
+                        </Typography>
+                    )}
+                    {connection.delay !== undefined && connection.delay > 0 && (
+                        <Typography
+                            variant="body2"
+                            fontSize={xSmallFontSize}
+                            color={getDelayColor(connection.delay)}
+                        >
+                            +{connection.delay} min
+                        </Typography>
+                    )}
+                </Box>
+            </Box>
+        </Box>
+    )
+}
+
+const TrainConnection = memo(TrainConnectionComponent)
+TrainConnection.displayName = 'TrainConnection'
+
+const TrainTimes = memo(TrainTimesComponent)
+TrainTimes.displayName = 'TrainTimes'
+
+export default TrainTimes

--- a/frontend/src/components/train_times/TrainTimes.tsx
+++ b/frontend/src/components/train_times/TrainTimes.tsx
@@ -5,7 +5,8 @@ import { memo } from 'react'
 import { useGetTrainConnections } from '../../apis/trains'
 import { useGetUserSettings } from '../../apis/user_settings'
 import { TrainConnection as TrainConnectionType } from '../../models/trains'
-import { xSmallFontSize } from '../../assets/styles/theme'
+import { PAPER_CARD_COLOR, xSmallFontSize } from '../../assets/styles/theme'
+import ErrorCard from '../error_card/ErrorCard'
 
 const TrainTimesComponent = () => {
     const { data: userSettings } = useGetUserSettings(false)
@@ -23,15 +24,21 @@ const TrainTimesComponent = () => {
         error,
     } = useGetTrainConnections(departureStationId, arrivalStationId, enabled)
 
-    if (!enabled) {
-        return null // Don't render if no stations are configured
+    if (!enabled && !isLoading) {
+        return (
+            <ErrorCard
+                Card={MediumCard}
+                error="Departure and or arrival station are not set. Please set them in the settings"
+                showSettingsBtn
+            />
+        )
     }
 
     return (
         <MediumCard>
             <Box height="100%">
                 <Typography variant="body1" marginBottom={1}>
-                    TRAIN TIMES
+                    Train Times
                 </Typography>
                 <Typography
                     variant="body2"
@@ -44,8 +51,12 @@ const TrainTimesComponent = () => {
                 <Stack spacing={1} direction="column">
                     {isLoading && (
                         <>
-                            {Array.from({ length: 3 }, (_, index) => (
-                                <Skeleton key={index} variant="rounded" height={60} />
+                            {Array.from({ length: 2 }, (_, index) => (
+                                <Skeleton
+                                    key={index}
+                                    variant="rounded"
+                                    height={50}
+                                />
                             ))}
                         </>
                     )}
@@ -71,12 +82,14 @@ const TrainTimesComponent = () => {
                     {!isLoading &&
                         !error &&
                         connections &&
-                        connections.map((connection, index) => (
-                            <TrainConnection
-                                key={`${connection.departure}-${index}`}
-                                connection={connection}
-                            />
-                        ))}
+                        connections
+                            .slice(0, 2)
+                            .map((connection, index) => (
+                                <TrainConnection
+                                    key={`${connection.departure}-${index}`}
+                                    connection={connection}
+                                />
+                            ))}
                 </Stack>
             </Box>
         </MediumCard>
@@ -118,7 +131,7 @@ const TrainConnectionComponent = ({ connection }: TrainConnectionProps) => {
             sx={{
                 padding: 1,
                 borderRadius: 1,
-                backgroundColor: 'background.paper',
+                backgroundColor: PAPER_CARD_COLOR,
                 border: 1,
                 borderColor: 'divider',
             }}
@@ -137,7 +150,8 @@ const TrainConnectionComponent = ({ connection }: TrainConnectionProps) => {
                         fontSize={xSmallFontSize}
                         color="text.secondary"
                     >
-                        {connection.line} • {formatDuration(connection.duration)}
+                        {connection.line} •{' '}
+                        {formatDuration(connection.duration)}
                     </Typography>
                 </Box>
                 <Box textAlign="right">

--- a/frontend/src/components/train_times/TrainTimes.tsx
+++ b/frontend/src/components/train_times/TrainTimes.tsx
@@ -122,7 +122,7 @@ const TrainConnectionComponent = ({ connection }: TrainConnectionProps) => {
 
     const getDelayColor = (delay?: number): string => {
         if (!delay || delay === 0) return 'text.primary'
-        if (delay > 0 && delay <= 5) return 'warning.main'
+        if (delay > 0 && delay <= 300) return 'warning.main'
         return 'error.main'
     }
 
@@ -170,7 +170,7 @@ const TrainConnectionComponent = ({ connection }: TrainConnectionProps) => {
                             fontSize={xSmallFontSize}
                             color={getDelayColor(connection.delay)}
                         >
-                            +{connection.delay} min
+                            +{connection.delay / 60} min
                         </Typography>
                     )}
                 </Box>

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -10,6 +10,7 @@ const EVENTS_ENDPOINT_CONTEXT = 'events'
 const CALENDARS_ENDPOINT_CONTEXT = 'calendars'
 const USERS_CONTEXT = 'users'
 const USER_SETTINGS_CONTEXT = `${USERS_CONTEXT}/settings`
+const TRAINS_ENDPOINT_CONTEXT = 'trains'
 export const WEATHER_API = `${BACKEND_BASE_URL}/${WEATHER_ENDPOINT_CONTEXT}`
 export const BIRHTDAY_API = `${BACKEND_BASE_URL}/${BIRTHDAY_ENDPOINT_CONTEXT}`
 export const USERS_API = `${BACKEND_BASE_URL}/${USERS_CONTEXT}`
@@ -21,6 +22,7 @@ export const LOGIN_URL = `${BACKEND_BASE_URL}/${AUTH_CONTEXT}/login`
 export const REGISTER_URL = `${BACKEND_BASE_URL}/${AUTH_CONTEXT}/register`
 export const LOGOUT_URL = `/oauth2/sign_out`
 export const LOCATION_API = `${BACKEND_BASE_URL}/location`
+export const TRAINS_API = `${BACKEND_BASE_URL}/${TRAINS_ENDPOINT_CONTEXT}`
 export const DEFAULT_FETCH_CONFIG: RequestInit = { credentials: 'include' }
 export const REFETCH_INTERVAL = parseInt(
     import.meta.env.REACT_APP_REFRESH_MILLIS ?? '120000'

--- a/frontend/src/models/trains.ts
+++ b/frontend/src/models/trains.ts
@@ -1,0 +1,19 @@
+export type TrainStation = {
+    id: string
+    name: string
+    latitude?: number
+    longitude?: number
+}
+
+export type TrainConnection = {
+    departure: string
+    arrival: string
+    departureStation: string
+    arrivalStation: string
+    departurePlatform?: string
+    arrivalPlatform?: string
+    line: string
+    direction: string
+    delay?: number
+    duration: number
+}

--- a/frontend/src/models/user_settings.ts
+++ b/frontend/src/models/user_settings.ts
@@ -4,4 +4,8 @@ export type UserSettings = {
     zip_code: string
     birthday_cal_id: string
     events_cal_id: string
+    train_departure_station_id?: string
+    train_departure_station_name?: string
+    train_arrival_station_id?: string
+    train_arrival_station_name?: string
 }

--- a/frontend/src/routes/Dashboard.tsx
+++ b/frontend/src/routes/Dashboard.tsx
@@ -5,6 +5,7 @@ import DailyForecast from '../components/daily_forecast/DailyForecast'
 import Birthdays from '../components/birthdays/Birthdays'
 import HourlyWeather from '../components/hourly_forecast/HourlyForecast'
 import UpcomingEvents from '../components/upcoming_events/UpcomingEvents'
+import TrainTimes from '../components/train_times/TrainTimes'
 import { TimeContextProvider } from '../common/TimeContext'
 import { LocationContextProvider } from '../common/LocationContext'
 import { PADDING } from '../assets/styles/theme'
@@ -44,6 +45,13 @@ const DashBoardItems = memo(() => {
                 }}
             >
                 <UpcomingEvents />
+            </Box>
+            <Box
+                sx={{
+                    gridColumn: { xs: 'span 1', sm: 'span 2' },
+                }}
+            >
+                <TrainTimes />
             </Box>
             <Box
                 sx={{

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -84,10 +84,14 @@ const SettingsComponent = () => {
                     zipCode: userSettings?.zip_code ?? DEFAULT_ZIP_CODE,
                     birthdayCalId: userSettings?.birthday_cal_id ?? '',
                     eventsCalId: userSettings?.events_cal_id ?? '',
-                    trainDepartureStationId: userSettings?.train_departure_station_id,
-                    trainDepartureStationName: userSettings?.train_departure_station_name,
-                    trainArrivalStationId: userSettings?.train_arrival_station_id,
-                    trainArrivalStationName: userSettings?.train_arrival_station_name,
+                    trainDepartureStationId:
+                        userSettings?.train_departure_station_id,
+                    trainDepartureStationName:
+                        userSettings?.train_departure_station_name,
+                    trainArrivalStationId:
+                        userSettings?.train_arrival_station_id,
+                    trainArrivalStationName:
+                        userSettings?.train_arrival_station_name,
                 }}
                 onBack={handleBack}
                 showBackButton={error == null}

--- a/frontend/src/routes/Settings.tsx
+++ b/frontend/src/routes/Settings.tsx
@@ -18,13 +18,23 @@ const inputHasChanged = (
     data: SettingsParams,
     userSettings?: UserSettings
 ): boolean => {
-    const { country, city, zipCode, eventsCalId, birthdayCalId } = data
+    const {
+        country,
+        city,
+        zipCode,
+        eventsCalId,
+        birthdayCalId,
+        trainDepartureStationId,
+        trainArrivalStationId,
+    } = data
     return (
         country !== userSettings?.country ||
         city !== userSettings?.city ||
         zipCode !== userSettings?.zip_code ||
         eventsCalId !== userSettings?.events_cal_id ||
-        birthdayCalId !== userSettings?.birthday_cal_id
+        birthdayCalId !== userSettings?.birthday_cal_id ||
+        trainDepartureStationId !== userSettings?.train_departure_station_id ||
+        trainArrivalStationId !== userSettings?.train_arrival_station_id
     )
 }
 
@@ -74,6 +84,10 @@ const SettingsComponent = () => {
                     zipCode: userSettings?.zip_code ?? DEFAULT_ZIP_CODE,
                     birthdayCalId: userSettings?.birthday_cal_id ?? '',
                     eventsCalId: userSettings?.events_cal_id ?? '',
+                    trainDepartureStationId: userSettings?.train_departure_station_id,
+                    trainDepartureStationName: userSettings?.train_departure_station_name,
+                    trainArrivalStationId: userSettings?.train_arrival_station_id,
+                    trainArrivalStationName: userSettings?.train_arrival_station_name,
                 }}
                 onBack={handleBack}
                 showBackButton={error == null}


### PR DESCRIPTION
This commit implements a complete train times feature that displays real-time
Deutsche Bahn train connections on the dashboard:

Backend changes:
- Add Deutsche Bahn API service using v6.db.transport.rest REST API
- Create train endpoints: /api/trains/stations, /api/trains/departures, /api/trains/connections
- Add train models for stations and connections
- Extend user settings model with train station preferences (departure/arrival stations)
- Add comprehensive unit tests for all train endpoints

Frontend changes:
- Create TrainTimes component to display next train connections
- Add train station selection fields to settings form with autocomplete
- Integrate TrainTimes component into dashboard
- Create React Query hooks for train data fetching
- Update user settings model and APIs to support train preferences

Features:
- Users can configure departure and arrival stations in settings
- Real-time display of next 5 train connections
- Shows departure/arrival times, duration, platform, and delays
- Auto-refreshes every minute
- Gracefully handles cases when no stations are configured