### PR TITLE
Add privacy policy markdown and index page for GitHub Pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,5 @@
+# Magic Mirror
+
+A personalized smart display dashboard showing real-time weather, calendar events, birthdays, and time.
+
+[Privacy Policy](privacy.md)

--- a/privacy.html
+++ b/privacy.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head><title>Privacy Policy</title></head>
-<body>
-  <h1>Privacy Policy</h1>
-  <p>This application is for personal use only.
-     No data is collected, stored, or shared with third parties.</p>
-</body>
-</html>

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,3 @@
+# Privacy Policy
+
+This application is for personal use only. No data is collected, stored, or shared with third parties.


### PR DESCRIPTION
Converts privacy.html to privacy.md and adds index.md homepage
with a link to the privacy policy for Google OIDC verification.

https://claude.ai/code/session_01R5dTJJFJ8cERQErphuUaCn