### PR TITLE
Add direct privacy policy link to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,4 +161,4 @@ Configure your inventory hosts and variables in `ansible/inventory/`.
 
 ---
 
-[Impressum / Privacy Policy](impressum.md)
+[Impressum](impressum.md) | [Privacy Policy](privacy.md)


### PR DESCRIPTION
Google OAuth branding verification requires the homepage to link directly
to the privacy policy URL. Previously the homepage only linked to
impressum.md which then linked to privacy.md — an indirect chain Google
doesn't recognize. Now both links are present directly on the homepage.

https://claude.ai/code/session_01HHrmBgFKehkLmP6np9EcdG