### PR TITLE
Add caching layer for API and Google Calendar requests

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -52,6 +52,8 @@ export const DB_API_BASE_URL = 'https://v6.db.transport.rest';
 
 export const ALLOWED_URLS = [WEATHER_API_URL, OPENWEATHER_URL, GEOCODE_URL, DB_API_BASE_URL];
 
+export const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 export const RATE_LIMIT = {
   windowMs: 1 * 60 * 1000, // 1 minute
   max: 500,

--- a/backend/src/routes/birthdays/index.ts
+++ b/backend/src/routes/birthdays/index.ts
@@ -3,7 +3,9 @@ import { NextFunction, Request, Response } from 'express';
 import { calendar_v3 } from 'googleapis';
 import { ApiError } from 'models/api/api_error';
 import { Birthday, BirthdayList } from 'models/api/birthdays';
+import { apiCache } from 'services/cache';
 import { getGoogleCalendar } from 'services/google';
+import { getUserId } from 'services/headers';
 import { getRouter } from 'services/router_factory';
 import { EParamType } from 'services/validators/parameter_validator';
 import { RangeParameterValidator } from 'services/validators/range_parameter_validator';
@@ -34,6 +36,14 @@ class BirthdayParser {
 // Calendar Event Retrieval Service
 class CalendarEventRetriever {
   static async getBirthdays(req: Request, calendarId: string, maxResults: number): Promise<calendar_v3.Schema$Events> {
+    const userId = getUserId(req.headers);
+    const cacheKey = `${userId}:birthdays:${calendarId}:${maxResults}`;
+
+    const cached = apiCache.get<calendar_v3.Schema$Events>(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const calendar = getGoogleCalendar(req);
     const timeMin = new Date().toISOString();
 
@@ -44,7 +54,11 @@ class CalendarEventRetriever {
       singleEvents: true,
       orderBy: 'startTime',
     });
-    return events.data;
+    const result = events.data;
+
+    apiCache.set(cacheKey, result);
+
+    return result;
   }
 }
 

--- a/backend/src/routes/calendars/index.ts
+++ b/backend/src/routes/calendars/index.ts
@@ -1,15 +1,31 @@
 import { NextFunction, Request, Response } from 'express';
 import { calendar_v3 } from 'googleapis';
 import { ApiError } from 'models/api/api_error';
+import { apiCache } from 'services/cache';
 import { getGoogleCalendar } from 'services/google';
+import { getUserId } from 'services/headers';
 import { getRouter } from 'services/router_factory';
 
 // Calendar List Retrieval Service
 class CalendarListRetriever {
   static async getCalendarList(req: Request): Promise<calendar_v3.Schema$CalendarListEntry[] | undefined> {
+    const userId = getUserId(req.headers);
+    const cacheKey = `${userId}:calendars`;
+
+    const cached = apiCache.get<calendar_v3.Schema$CalendarListEntry[]>(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const calendar = getGoogleCalendar(req);
     const calendars = await calendar.calendarList.list({ maxResults: 100 });
-    return calendars.data.items;
+    const result = calendars.data.items;
+
+    if (result !== undefined) {
+      apiCache.set(cacheKey, result);
+    }
+
+    return result;
   }
 }
 

--- a/backend/src/routes/events/index.ts
+++ b/backend/src/routes/events/index.ts
@@ -38,7 +38,8 @@ class CalendarEventService {
     calendarId: string,
   ): Promise<calendar_v3.Schema$Events> {
     const userId = getUserId(req.headers);
-    const cacheKey = `${userId}:events:${calendarId}:${timeMin}:${timeMax ?? ''}:${maxResults}`;
+    const cacheTime = timeMin.includes('T') ? timeMin.substring(0, 16) : timeMin;
+    const cacheKey = `${userId}:events:${calendarId}:${cacheTime}:${timeMax ?? ''}:${maxResults}`;
 
     const cached = apiCache.get<calendar_v3.Schema$Events>(cacheKey);
     if (cached !== undefined) {

--- a/backend/src/routes/events/index.ts
+++ b/backend/src/routes/events/index.ts
@@ -4,7 +4,9 @@ import { calendar_v3 } from 'googleapis';
 import { ApiError } from 'models/api/api_error';
 import { CalendarEvent, CalendarEventList } from 'models/api/calendar'; // Import CalendarEvent type
 import { getTimeDiff, isDate, isIso8601DatetimeString, TimeUnit } from 'services/dateParser';
+import { apiCache } from 'services/cache';
 import { getGoogleCalendar } from 'services/google';
+import { getUserId } from 'services/headers';
 import { getRouter } from 'services/router_factory';
 import { CustomParameterValidator } from 'services/validators/custom_parameter_validator';
 import { EParamType } from 'services/validators/parameter_validator';
@@ -35,6 +37,14 @@ class CalendarEventService {
     maxResults: number,
     calendarId: string,
   ): Promise<calendar_v3.Schema$Events> {
+    const userId = getUserId(req.headers);
+    const cacheKey = `${userId}:events:${calendarId}:${timeMin}:${timeMax ?? ''}:${maxResults}`;
+
+    const cached = apiCache.get<calendar_v3.Schema$Events>(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
     const calendar = getGoogleCalendar(req);
     const events = await calendar.events.list({
       calendarId,
@@ -44,7 +54,11 @@ class CalendarEventService {
       singleEvents: true,
       orderBy: 'startTime',
     });
-    return events.data;
+    const result = events.data;
+
+    apiCache.set(cacheKey, result);
+
+    return result;
   }
 
   static parseEvents(events: calendar_v3.Schema$Events): CalendarEventList {

--- a/backend/src/routes/events/index.ts
+++ b/backend/src/routes/events/index.ts
@@ -87,10 +87,11 @@ class CalendarEventService {
 // Route Handlers
 async function allCalendarEvents(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    const maxResults = parseInt((req.query.count as string) || String(CALENDAR_CONFIG.DEFAULT_EVENT_COUNT));
-    const timeMin = (req.query.minTime as string) || new Date().toISOString();
-    const timeMax = req.query.maxTime as string | undefined;
-    const calId = (req.query.cal_id as string) || 'primary';
+    const countParam = typeof req.query.count === 'string' ? req.query.count : undefined;
+    const maxResults = parseInt(countParam || String(CALENDAR_CONFIG.DEFAULT_EVENT_COUNT));
+    const timeMin = typeof req.query.minTime === 'string' ? req.query.minTime : new Date().toISOString();
+    const timeMax = typeof req.query.maxTime === 'string' ? req.query.maxTime : undefined;
+    const calId = typeof req.query.cal_id === 'string' ? req.query.cal_id : 'primary';
 
     const events = await CalendarEventService.getEvents(req, timeMin, timeMax, maxResults, calId);
     const parsedEvents = CalendarEventService.parseEvents(events);
@@ -107,7 +108,7 @@ async function eventsAtDate(req: Request, res: Response, next: NextFunction): Pr
     const timeMin = new Date(date).toISOString();
     const timeMax = new Date(date);
     timeMax.setDate(timeMax.getDate() + 1);
-    const calId = (req.query.cal_id as string) || 'primary';
+    const calId = typeof req.query.cal_id === 'string' ? req.query.cal_id : 'primary';
 
     const events = await CalendarEventService.getEvents(req, timeMin, timeMax.toISOString(), 100, calId);
     const parsedEvents = CalendarEventService.parseEvents(events);

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -9,6 +9,18 @@ interface CacheEntry<T> {
 class ApiCacheService {
   private readonly store = new Map<string, CacheEntry<unknown>>();
 
+  constructor() {
+    // Periodically prune expired entries to prevent memory leaks
+    setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of this.store.entries()) {
+        if (now > entry.expiresAt) {
+          this.store.delete(key);
+        }
+      }
+    }, 30 * 60 * 1000).unref();
+  }
+
   get<T>(key: string): T | undefined {
     const entry = this.store.get(key) as CacheEntry<T> | undefined;
     if (!entry) return undefined;

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -12,14 +12,17 @@ class ApiCacheService {
 
   constructor() {
     // Periodically prune expired entries to prevent memory leaks
-    setInterval(() => {
-      const now = Date.now();
-      for (const [key, entry] of this.store.entries()) {
-        if (now > entry.expiresAt) {
-          this.store.delete(key);
+    setInterval(
+      () => {
+        const now = Date.now();
+        for (const [key, entry] of this.store.entries()) {
+          if (now > entry.expiresAt) {
+            this.store.delete(key);
+          }
         }
-      }
-    }, 30 * 60 * 1000).unref();
+      },
+      30 * 60 * 1000,
+    ).unref();
   }
 
   get<T>(key: string): T | undefined {

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -1,0 +1,32 @@
+import { CACHE_TTL_MS } from 'config';
+import { LOGGER } from 'services/loggers';
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+class ApiCacheService {
+  private readonly store = new Map<string, CacheEntry<unknown>>();
+
+  get<T>(key: string): T | undefined {
+    const entry = this.store.get(key) as CacheEntry<T> | undefined;
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      LOGGER.debug(`Cache expired for key: ${key}`);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set<T>(key: string, value: T): void {
+    this.store.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+export const apiCache = new ApiCacheService();

--- a/backend/src/services/cache.ts
+++ b/backend/src/services/cache.ts
@@ -7,6 +7,7 @@ interface CacheEntry<T> {
 }
 
 class ApiCacheService {
+  private static readonly MAX_SIZE = 500;
   private readonly store = new Map<string, CacheEntry<unknown>>();
 
   constructor() {
@@ -33,6 +34,10 @@ class ApiCacheService {
   }
 
   set<T>(key: string, value: T): void {
+    if (!this.store.has(key) && this.store.size >= ApiCacheService.MAX_SIZE) {
+      const oldestKey = this.store.keys().next().value as string;
+      this.store.delete(oldestKey);
+    }
     this.store.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
   }
 

--- a/backend/src/services/fetch.ts
+++ b/backend/src/services/fetch.ts
@@ -19,7 +19,8 @@ export const fetchJson = async (
 ): Promise<ApiResponse<Json>> => {
   const displayUrl = logUrl ?? url;
 
-  const cached = apiCache.get<ApiResponse<Json>>(url);
+  const cacheKey = `${options.method ?? 'GET'}:${url}`;
+  const cached = apiCache.get<ApiResponse<Json>>(cacheKey);
   if (cached) {
     LOGGER.info(`Cache hit for ${displayUrl}`);
     return cached;
@@ -50,7 +51,7 @@ export const fetchJson = async (
     };
 
     if (result.statusOk) {
-      apiCache.set(url, result);
+      apiCache.set(cacheKey, result);
     }
 
     return result;
@@ -75,7 +76,8 @@ export const fetchBuffer = async (
 ): Promise<ApiResponse<ArrayBuffer>> => {
   const displayUrl = logUrl ?? url;
 
-  const cached = apiCache.get<ApiResponse<ArrayBuffer>>(url);
+  const cacheKey = `${options.method ?? 'GET'}:${url}`;
+  const cached = apiCache.get<ApiResponse<ArrayBuffer>>(cacheKey);
   if (cached) {
     LOGGER.info(`Cache hit for ${displayUrl}`);
     return cached;
@@ -97,7 +99,7 @@ export const fetchBuffer = async (
     };
 
     if (result.statusOk) {
-      apiCache.set(url, result);
+      apiCache.set(cacheKey, result);
     }
 
     return result;

--- a/backend/src/services/fetch.ts
+++ b/backend/src/services/fetch.ts
@@ -1,10 +1,11 @@
 import { ALLOWED_URLS } from 'config';
 import { ApiError } from 'models/api/api_error';
 import { ApiResponse, Json } from 'models/api/fetch';
+import { apiCache } from 'services/cache';
 import { LOGGER } from 'services/loggers';
 
 /**
- * Fetches JSON data from an external API with URL validation and logging
+ * Fetches JSON data from an external API with URL validation, caching, and logging
  * @param url - URL to fetch from (must be in ALLOWED_URLS)
  * @param options - Fetch options (headers, method, etc.)
  * @param logUrl - Optional URL to display in logs (for security)
@@ -17,6 +18,13 @@ export const fetchJson = async (
   logUrl?: string,
 ): Promise<ApiResponse<Json>> => {
   const displayUrl = logUrl ?? url;
+
+  const cached = apiCache.get<ApiResponse<Json>>(url);
+  if (cached) {
+    LOGGER.info(`Cache hit for ${displayUrl}`);
+    return cached;
+  }
+
   LOGGER.info(`Calling API ${displayUrl} to get JSON`);
 
   checkInputURL(url);
@@ -35,11 +43,17 @@ export const fetchJson = async (
       throw parseError;
     }
 
-    return {
+    const result: ApiResponse<Json> = {
       body,
       status: response.status,
       statusOk: response.ok,
     };
+
+    if (result.statusOk) {
+      apiCache.set(url, result);
+    }
+
+    return result;
   } catch (err) {
     LOGGER.error(`Call to API ${displayUrl} returned error`, { error: err });
     throw err;
@@ -47,7 +61,7 @@ export const fetchJson = async (
 };
 
 /**
- * Fetches binary data (ArrayBuffer) from an external API
+ * Fetches binary data (ArrayBuffer) from an external API with caching
  * @param url - URL to fetch from (must be in ALLOWED_URLS)
  * @param options - Fetch options (headers, method, etc.)
  * @param logUrl - Optional URL to display in logs (for security)
@@ -60,6 +74,13 @@ export const fetchBuffer = async (
   logUrl?: string,
 ): Promise<ApiResponse<ArrayBuffer>> => {
   const displayUrl = logUrl ?? url;
+
+  const cached = apiCache.get<ApiResponse<ArrayBuffer>>(url);
+  if (cached) {
+    LOGGER.info(`Cache hit for ${displayUrl}`);
+    return cached;
+  }
+
   LOGGER.info(`Calling API ${displayUrl} to get binary data`);
 
   checkInputURL(url);
@@ -69,11 +90,17 @@ export const fetchBuffer = async (
     LOGGER.info(`Call to API ${displayUrl} returned status code ${response.status}`);
 
     const body = await response.arrayBuffer();
-    return {
+    const result: ApiResponse<ArrayBuffer> = {
       body,
       status: response.status,
       statusOk: response.ok,
     };
+
+    if (result.statusOk) {
+      apiCache.set(url, result);
+    }
+
+    return result;
   } catch (err) {
     LOGGER.error(`Call to API ${displayUrl} returned error`, { error: err });
     throw err;


### PR DESCRIPTION
## Summary
Implements a caching service to reduce redundant API calls to external services and Google Calendar APIs. All cached responses are stored with a 5-minute TTL and are automatically invalidated after expiration.

## Key Changes
- **New Cache Service** (`backend/src/services/cache.ts`):
  - Created `ApiCacheService` class with generic `get<T>()` and `set<T>()` methods
  - Implements automatic TTL-based expiration (5 minutes by default)
  - Logs cache hits and expirations for debugging
  - Provides `clear()` method for manual cache invalidation

- **Updated Fetch Service** (`backend/src/services/fetch.ts`):
  - Added cache lookup before making external API calls in `fetchJson()` and `fetchBuffer()`
  - Only caches successful responses (HTTP 2xx status codes)
  - Logs cache hits to track caching effectiveness
  - Updated JSDoc comments to reflect caching functionality

- **Updated Calendar Routes** (`backend/src/routes/calendars/index.ts`, `birthdays/index.ts`, `events/index.ts`):
  - Integrated caching into `CalendarListRetriever`, `CalendarEventRetriever`, and `CalendarEventService`
  - Cache keys include user ID to prevent cross-user data leakage
  - Cache keys include relevant query parameters (calendar ID, date ranges, max results) to ensure cache correctness

- **Configuration** (`backend/src/config/index.ts`):
  - Added `CACHE_TTL_MS` constant set to 5 minutes (configurable)

## Implementation Details
- Cache keys for Google Calendar operations are scoped by user ID to maintain data isolation
- Only successful API responses are cached to avoid caching error states
- Cache expiration is checked on retrieval, with expired entries automatically removed
- The caching layer is transparent to callers and doesn't change the public API

https://claude.ai/code/session_018FN9ivK5vw4paTGdvkddnT